### PR TITLE
Update default Competitive Companion port to 10043

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ Competitive companion is a browser extension that helps to parse problems from v
 
 For setting the competitive companion, you have to install the extension to your browser. Just search google, you will find the extension.
 
-By default this project listens on port 10044, which is a port Competitive Companion already sends parsed problems to by default. If you change the port this project listens on for problems received from Competitive Companion, you'll need to make sure Competitive Companion is properly configured to send problems to that port. To do this, right-click on the extension icon and click "Manage Extension". Then go to "Preferences" and add the port to the "Custom ports" field.
+By default this project listens on port 10043, which is a port Competitive Companion already sends parsed problems to by default. If you change the port this project listens on for problems received from Competitive Companion, you'll need to make sure Competitive Companion is properly configured to send problems to that port. To do this, right-click on the extension icon and click "Manage Extension". Then go to "Preferences" and add the port to the "Custom ports" field.
 
 To open config write the following command,
 

--- a/README.md
+++ b/README.md
@@ -415,8 +415,7 @@ Competitive companion is a browser extension that helps to parse problems from v
 
 For setting the competitive companion, you have to install the extension to your browser. Just search google, you will find the extension.
 
-After installing, right-click on the extension and click manage extension. Then go to 'Preference' and write custom port 8080.
-Because the default port number in my project is 8080. If you want to change the port, you can change from the config.
+By default this project listens on port 10044, which is a port Competitive Companion already sends parsed problems to by default. If you change the port this project listens on for problems received from Competitive Companion, you'll need to make sure Competitive Companion is properly configured to send problems to that port. To do this, right-click on the extension icon and click "Manage Extension". Then go to "Preferences" and add the port to the "Custom ports" field.
 
 To open config write the following command,
 

--- a/settings/compiler.py
+++ b/settings/compiler.py
@@ -19,7 +19,7 @@ template_path = {
 }
 
 coder_name = bot['boss']
-competitive_companion_port = 8080
+competitive_companion_port = 10044
 
 parse_problem_with_template = True # If true, after parsing all the codes will contain a file name sol.cpp (with your template)
 

--- a/settings/compiler.py
+++ b/settings/compiler.py
@@ -19,7 +19,7 @@ template_path = {
 }
 
 coder_name = bot['boss']
-competitive_companion_port = 10044
+competitive_companion_port = 10043
 
 parse_problem_with_template = True # If true, after parsing all the codes will contain a file name sol.cpp (with your template)
 

--- a/settings/default.conf
+++ b/settings/default.conf
@@ -20,7 +20,7 @@ text_read = True
 
 [cp]
 coder_name = ${boss}
-competitive_companion_port = 8080
+competitive_companion_port = 10044
 parse_problem_with_template = True
 
 

--- a/settings/default.conf
+++ b/settings/default.conf
@@ -20,7 +20,7 @@ text_read = True
 
 [cp]
 coder_name = ${boss}
-competitive_companion_port = 10044
+competitive_companion_port = 10043
 parse_problem_with_template = True
 
 


### PR DESCRIPTION
Title says it all. After this PR is merged I'll also add this project to Competitive Companion's README and to its blog post on Codeforces as requested in your PM on Codeforces.

The reason why this change is required is that Codeforces cannot send problem data to port 8080 because that is a common port used for local servers, which may cause conflicts when Competitive Companion sends HTTP requests to it.